### PR TITLE
vayu: Pass display ID to sensor location

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -7,4 +7,4 @@ ro.surface_flinger.set_touch_timer_ms=200
 
 # Fingerprint
 persist.vendor.fingerprint.type=side
-persist.vendor.fingerprint.sensor_location=1080|945|150|local:4630946480857061761
+persist.vendor.fingerprint.sensor_location=1080|945|150|local:4630946480857061761,1080|945|150|local:4630946545580055169


### PR DESCRIPTION
Fixes wrong side fps overlay on Android V.

vayu has two types of display panels.

Change-Id: I7d5fd33d6e58760daa6ac6ce8aa8ccc40cfbd3c1